### PR TITLE
Fix user configuration file default path

### DIFF
--- a/icepapcms/__main__.py
+++ b/icepapcms/__main__.py
@@ -31,13 +31,13 @@ def get_parser():
                         action='store', type=str, dest='config_file', 
                         help='Path to configuration file. '
                              'Defaults to trying first {}/icepapcms.conf,'
-                             ' then ~/.icepapcms/configs/icepapcms.conf'
+                             ' then ~/.icepapcms/icepapcms.conf'
                              .format(system_config_path))
     parser.add_argument('-u', '--user',
                         action='store_true', dest='user_config', 
                         help='Ignore system-wide config.'
                              ' Only use config in user home directory, '
-                             ' ~/.icepapcms/configs/icepapcms.conf')
+                             ' ~/.icepapcms/icepapcms.conf')
     parser.add_argument("--debug-level", dest='debug_level', type=str,
                         help='Logging level used:[DEBUG, INFO, WARNING, '
                              'ERROR, CRITICAL]', default='WARNING')

--- a/icepapcms/lib/configmanager.py
+++ b/icepapcms/lib/configmanager.py
@@ -38,9 +38,9 @@ class ConfigManager(Singleton):
     use_user_config = False
 
     if os.name == "nt":
-        conf_path_list = [os.path.expandvars("%PROGRAMDATA%/IcePAP"), os.path.expanduser("~/.icepapcms/configs")]
+        conf_path_list = [os.path.expandvars("%PROGRAMDATA%/IcePAP"), os.path.expanduser("~/.icepapcms")]
     else:    
-        conf_path_list = ["/etc/icepap", os.path.expanduser("~/.icepapcms/configs")]
+        conf_path_list = ["/etc/icepap", os.path.expanduser("~/.icepapcms")]
 
     username = 'NotValidated'
 
@@ -123,7 +123,7 @@ class ConfigManager(Singleton):
         
         # If config filename is still None, default to the user home dir.
         if self.config_filename is None:
-            self.configs_folder = os.path.expanduser("~/.icepapcms/configs")
+            self.configs_folder = os.path.expanduser("~/.icepapcms")
             self.config_filename = os.path.join(self.configs_folder, "icepapcms.conf")
             if not os.path.exists(self.configs_folder):
                 os.makedirs(self.configs_folder)


### PR DESCRIPTION
Fix default path for user configuration file

## Description

The directory `~/.icepapcms/configs` is intended for driver configuration files (xml).

As such, on no system wide configuration file or `--user` option, the default path for the IcePAP CMS configuration file should be
`~/.icepapcms/icepapcms.conf`. This is the default behaviour in versions <3.3.0.

## Notes

* Branched from `systemwideconfig` rather than `master` as was unsure if safe to pull from upstream. Can always pull and rebase onto `master` if preferred.
* **No build or testing performed yet!**